### PR TITLE
Implement saving between sessions

### DIFF
--- a/src/components/Teatime/Teatime.module.css
+++ b/src/components/Teatime/Teatime.module.css
@@ -1,3 +1,5 @@
+@value timingIconSize: 40px;
+
 .header {
 	display: flex;
 }

--- a/src/components/Teatime/Teatime.module.css.d.ts
+++ b/src/components/Teatime/Teatime.module.css.d.ts
@@ -6,6 +6,7 @@ declare namespace TeatimeModuleCssModule {
     header: string;
     resultsContainer: string;
     seeMore: string;
+    timingIconSize: string;
   }
 }
 


### PR DESCRIPTION
Adding or removing a timing now immediately updates localStorage. This enables persistence through both modal close/reopen and refresh.

I also swapped out pure icons for ActionLinks and removed the unnecessary Search bar.

![image](https://user-images.githubusercontent.com/29166401/72108369-4a629e80-32e8-11ea-8db8-e629f538b45e.png)
